### PR TITLE
Resolve #27: Add HMAC sigs to Drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 # Shared node_modules between subsequent tests imposes
 # DAG dependencies that are not conducive for multiple
 # parallel pipelines; a refined solution must be found.
@@ -317,3 +318,9 @@ steps:
     target:
     - apply-stage
 
+
+---
+kind: signature
+hmac: ce8e85761aab4caa14b309d7fd708f40247615ea6f3f16100d383db0eb08a131
+
+...


### PR DESCRIPTION
 - Add signature signing to Drone pipeline to restrict
   public repository read access from exploiting pipeline
   secrets. Changing the pipeline requires elevated privileges.
 - Rename '.drone.yaml' to '.drone.yml'